### PR TITLE
specify Int64 for sparsity jacobian

### DIFF
--- a/src/fmincon_dense.jl
+++ b/src/fmincon_dense.jl
@@ -43,8 +43,8 @@ end
 
 function sparsity_jacobian(n,m)
 
-    row = []
-    col = []
+    row = Int64[]
+    col = Int64[]
 
     r = 1:m
     c = 1:n


### PR DESCRIPTION
for some reason MOI complains about the vector types in sparsity_jacobian with the newer versions of Julia. we fixed in the OCRL assignments this year. tests now pass.